### PR TITLE
Feat/porject guard

### DIFF
--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -28,10 +28,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     const { email } = payload;
     const user = await this._userRepository.findOne({
       where: { email, status: this._statusEnum.ACTIVE },
+      relations: ['rolesGranted', 'rolesGranted.role'],
     });
 
     if (!user) throw new UnauthorizedException();
 
-    return payload;
+    return user;
   }
 }

--- a/src/modules/nft/controllers/nft.controller.ts
+++ b/src/modules/nft/controllers/nft.controller.ts
@@ -20,8 +20,8 @@ import { WalletService } from '../../wallet/services/wallet.service';
 import { DeployNftDto } from '../dto/deploy-nft.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { RoleProtect } from '../../role/decorators/role.decorator';
-import { RoleGuard } from "../../role/guards/role.guard";
-import { ApiKeyGuard } from "../../project/guards/api-key.guard";
+import { RoleGuard } from '../../role/guards/role.guard';
+import { ApiKeyGuard } from '../../project/guards/api-key.guard';
 
 @Controller('nft')
 @UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
@@ -40,7 +40,7 @@ export class NftController {
   @Post()
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.CREATED)
-  @RoleProtect('MEMBER', 'SUPER_ADMIN')
+  @RoleProtect('MEMBER', 'ADMIN', 'SUPER_ADMIN')
   public async deployERC721Token(
     @Body() tokenParams: DeployNftDto,
     @Query('chain') chain: string,
@@ -64,12 +64,14 @@ export class NftController {
   }
 
   @Get('owner/:tokenId')
+  @RoleProtect('MEMBER', 'ADMIN', 'SUPER_ADMIN')
   async getOwnerOfERC721Token(@Param('tokenId') tokenId: string) {
     const owner = await this.nftService.ownerOfERC721(tokenId);
     return { owner };
   }
 
   @Get('token_URI/:tokenId')
+  @RoleProtect('MEMBER', 'ADMIN', 'SUPER_ADMIN')
   async getUriOfToken(@Param('tokenId') tokenId: string) {
     const tokenURI = await this.nftService.getTokenURI(tokenId);
     return { tokenURI };

--- a/src/modules/nft/controllers/nft.controller.ts
+++ b/src/modules/nft/controllers/nft.controller.ts
@@ -11,15 +11,20 @@ import {
   UsePipes,
   ValidationPipe,
   Headers,
+  UseGuards,
 } from '@nestjs/common';
 
 // Local Dependencies.
 import { NftService } from '../services/nft.service';
 import { WalletService } from '../../wallet/services/wallet.service';
 import { DeployNftDto } from '../dto/deploy-nft.dto';
-import { AuthGuard } from "@nestjs/passport";
+import { AuthGuard } from '@nestjs/passport';
+import { RoleProtect } from '../../role/decorators/role.decorator';
+import { RoleGuard } from "../../role/guards/role.guard";
+import { ApiKeyGuard } from "../../project/guards/api-key.guard";
 
 @Controller('nft')
+@UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
 export class NftController {
   constructor(
     private readonly nftService: NftService,
@@ -35,7 +40,7 @@ export class NftController {
   @Post()
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.CREATED)
-  // @UseGuards(AuthGuard(), ApiKeyGuard)
+  @RoleProtect('MEMBER', 'SUPER_ADMIN')
   public async deployERC721Token(
     @Body() tokenParams: DeployNftDto,
     @Query('chain') chain: string,

--- a/src/modules/nft/controllers/nft.controller.ts
+++ b/src/modules/nft/controllers/nft.controller.ts
@@ -24,7 +24,7 @@ import { RoleGuard } from '../../role/guards/role.guard';
 import { ApiKeyGuard } from '../../project/guards/api-key.guard';
 
 @Controller('nft')
-@UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
+@UseGuards(ApiKeyGuard)
 export class NftController {
   constructor(
     private readonly nftService: NftService,
@@ -44,7 +44,7 @@ export class NftController {
   public async deployERC721Token(
     @Body() tokenParams: DeployNftDto,
     @Query('chain') chain: string,
-    @Headers('authorization') authHeader: string,
+    @Headers('x-api-key') authHeader: string,
   ): Promise<any> {
     try {
       const rpcUrl = await this.walletService.getRpcUrl(chain);

--- a/src/modules/nft/services/nft.service.ts
+++ b/src/modules/nft/services/nft.service.ts
@@ -25,7 +25,7 @@ export class NftService {
     wallet: Wallet,
     tokenParams: DeployNftDto,
     rpcUrl: string,
-    @Headers('authorization') authHeader: string,
+    @Headers('x-api-key') authHeader: string,
   ): Promise<any> {
     const { name, symbol } = tokenParams;
     const methodName = 'createNewContract(string,string)'; // TODO: Change this to the correct method name from the ABI.
@@ -37,13 +37,6 @@ export class NftService {
       wallet.connect(provider),
     );
     try {
-      // Obtener el usuario que solicita el despliegue
-      const project = await this._authProject.getProjectToken(authHeader);
-      // Comprobar que el usuario pertenece a la organización
-      if (!project.id) {
-        // Lanzar una excepción personalizada si no tiene los permisos necesarios
-        throw new ForbiddenException('No tienes permiso para desplegar este token NFT.');
-      }
       // Llamar al método del contrato inteligente para desplegar el token NFT
       const result = await contract[methodName](name, symbol);
       console.log(
@@ -52,14 +45,12 @@ export class NftService {
       );
       return result;
     } catch (error) {
-      // console.error(error);
       if (error.code === 'INSUFFICIENT_FUNDS') {
         const errorMessage =
           'Saldo insuficiente para cubrir el costo de la transacción';
 
-        // Puedes lanzar una excepción personalizada si lo prefieres
         throw new NotFoundException(errorMessage);
-      } 
+      }
       throw error;
     }
   }

--- a/src/modules/project/controllers/project.controller.ts
+++ b/src/modules/project/controllers/project.controller.ts
@@ -8,16 +8,21 @@ import {
   Param,
   Delete,
   Headers,
-  Query,
-} from '@nestjs/common';
+  Query, UseGuards
+} from "@nestjs/common";
 
 // Local Dependencies.
 import { ProjectService } from '../services/project.service';
 import { CreateProjectDto } from '../dto/create-project.dto';
 import { UpdateProjectDto } from '../dto/update-project.dto';
 import { Project } from '../entities/project.entity';
+import { RoleProtect } from "../../role/decorators/role.decorator";
+import { AuthGuard } from "@nestjs/passport";
+import { RoleGuard } from "../../role/guards/role.guard";
+import { ApiKeyGuard } from "../guards/api-key.guard";
 
 @Controller('project')
+@UseGuards(AuthGuard(), RoleGuard, ApiKeyGuard)
 export class ProjectController {
   constructor(private readonly _projectService: ProjectService) {}
 
@@ -29,6 +34,7 @@ export class ProjectController {
    * @returns {Promise<{ status: string; message: string; project_id: string }>}
    */
   @Post()
+  @RoleProtect('MEMBER','ADMIN', 'SUPER_ADMIN')
   create(
     @Headers('authorization') authHeader: string,
     @Body() createProjectDto: CreateProjectDto,
@@ -45,6 +51,7 @@ export class ProjectController {
    * @returns {Promise<Project[]>}
    */
   @Get()
+  @RoleProtect('MEMBER','ADMIN', 'SUPER_ADMIN')
   findAll(
     @Headers('authorization') authHeader: string,
     @Query('page') page: number,
@@ -61,6 +68,7 @@ export class ProjectController {
    * @returns {Promise<Project>}
    */
   @Get(':id')
+  @RoleProtect('MEMBER','ADMIN', 'SUPER_ADMIN')
   findOne(
     @Headers('authorization') authHeader: string,
     @Param('id') id: string,
@@ -77,6 +85,7 @@ export class ProjectController {
    * @returns {Promise<{ status: string; message: string }>}
    */
   @Patch(':id')
+  @RoleProtect('MEMBER','ADMIN', 'SUPER_ADMIN')
   update(
     @Headers('authorization') authHeader: string,
     @Param('id') id: string,
@@ -93,6 +102,7 @@ export class ProjectController {
    * @returns {Promise<{ status: string; message: string }>}
    */
   @Delete()
+  @RoleProtect('MEMBER','ADMIN', 'SUPER_ADMIN')
   remove(
     @Headers('authorization') authHeader: string,
     @Query('id') id: string,

--- a/src/modules/project/controllers/project.controller.ts
+++ b/src/modules/project/controllers/project.controller.ts
@@ -19,10 +19,9 @@ import { Project } from '../entities/project.entity';
 import { RoleProtect } from "../../role/decorators/role.decorator";
 import { AuthGuard } from "@nestjs/passport";
 import { RoleGuard } from "../../role/guards/role.guard";
-import { ApiKeyGuard } from "../guards/api-key.guard";
 
 @Controller('project')
-@UseGuards(AuthGuard(), RoleGuard, ApiKeyGuard)
+@UseGuards(AuthGuard(), RoleGuard)
 export class ProjectController {
   constructor(private readonly _projectService: ProjectService) {}
 

--- a/src/modules/project/guards/api-key.guard.ts
+++ b/src/modules/project/guards/api-key.guard.ts
@@ -11,10 +11,9 @@ export class ApiKeyGuard implements CanActivate {
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const apiKey = request.query['api-key'];
+    const apiKey = request.headers['x-api-key'];
+
     const user = request.user;
-    console.log('User 2:', user);
-    console.log('API Key:', apiKey);
 
     if (!apiKey) {
       return false;

--- a/src/modules/project/guards/api-key.guard.ts
+++ b/src/modules/project/guards/api-key.guard.ts
@@ -13,15 +13,13 @@ export class ApiKeyGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const apiKey = request.headers['x-api-key'];
 
-    const user = request.user;
-
     if (!apiKey) {
       return false;
     }
-    return this.validateApiKey(user, apiKey);
+    return this.validateApiKey(apiKey);
   }
 
-  async validateApiKey(user: User, apiKey: string): Promise<boolean> {
-    return await this.projectService.validateApiKey(user, apiKey);
+  async validateApiKey(apiKey: string): Promise<boolean> {
+    return await this.projectService.validateApiKey(apiKey);
   }
 }

--- a/src/modules/project/guards/api-key.guard.ts
+++ b/src/modules/project/guards/api-key.guard.ts
@@ -1,0 +1,28 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { ProjectService } from '../services/project.service';
+import { User } from '../../user/entities/user.entity';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private readonly projectService: ProjectService) {}
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const apiKey = request.query['api-key'];
+    const user = request.user;
+    console.log('User 2:', user);
+    console.log('API Key:', apiKey);
+
+    if (!apiKey) {
+      return false;
+    }
+    return this.validateApiKey(user, apiKey);
+  }
+
+  async validateApiKey(user: User, apiKey: string): Promise<boolean> {
+    return await this.projectService.validateApiKey(user, apiKey);
+  }
+}

--- a/src/modules/project/services/project.service.ts
+++ b/src/modules/project/services/project.service.ts
@@ -7,7 +7,7 @@ import {
   Logger,
   ConflictException,
   ForbiddenException,
-  UnauthorizedException
+  UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -34,7 +34,7 @@ export class ProjectService {
     private readonly _userRepository: Repository<User>,
     @InjectRepository(Access)
     private readonly _accessRepository: Repository<Access>,
-  ) { }
+  ) {}
 
   /**
    * @memberof ProjectService
@@ -278,5 +278,35 @@ export class ProjectService {
     // Check if Project exists.
     if (!project) throw new NotFoundException('Project not found.');
     return project;
+  }
+
+  /**
+   * @memberof ProjectService
+   * @param {User} user
+   * @param {string} apiKey
+   * @returns {Promise<boolean>}
+   */
+  async validateApiKey(user: User, apiKey: string): Promise<boolean> {
+    // Search for Project.
+    const project = await this.projectRepository.findOne({
+      where: { accessToken: apiKey },
+    });
+
+    // Search for Access.
+    const access = await this._accessRepository.findOne({
+      where: { user: user, project: project },
+    });
+
+    console.log('Access:', access);
+    console.log('Project:', project);
+
+    // Check if Access and Project exists.
+    if (!access || !project) {
+      throw new ForbiddenException(
+        'You do not have permission to perform this action.',
+      );
+    }
+
+    return true;
   }
 }

--- a/src/modules/project/services/project.service.ts
+++ b/src/modules/project/services/project.service.ts
@@ -267,6 +267,8 @@ export class ProjectService {
       throw new UnauthorizedException('Project header is missing.');
     // Verify if Project header is valid.
     const token = projectHeader.split(' ')[1];
+
+    console.log('token', token);
     // Check if token is provided.
     if (!token) throw new UnauthorizedException('Invalid token.');
     // Verify if token is valid.
@@ -286,22 +288,14 @@ export class ProjectService {
    * @param {string} apiKey
    * @returns {Promise<boolean>}
    */
-  async validateApiKey(user: User, apiKey: string): Promise<boolean> {
+  async validateApiKey(apiKey: string): Promise<boolean> {
     // Search for Project.
     const project = await this.projectRepository.findOne({
       where: { accessToken: apiKey },
     });
 
-    // Search for Access.
-    const access = await this._accessRepository.findOne({
-      where: { user: user, project: project },
-    });
-
-    console.log('Access:', access);
-    console.log('Project:', project);
-
     // Check if Access and Project exists.
-    if (!access || !project) {
+    if (!project) {
       throw new ForbiddenException(
         'You do not have permission to perform this action.',
       );

--- a/src/modules/requests/entities/request.entity.ts
+++ b/src/modules/requests/entities/request.entity.ts
@@ -1,39 +1,39 @@
 import {
-    Column,
-    Entity,
-    PrimaryGeneratedColumn,
-    UpdateDateColumn,
-  } from 'typeorm';
-  
-  @Entity('requests')
-  export class Requests {
-    @PrimaryGeneratedColumn()
-    id: number;
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
-    @Column({ name: 'projectId', nullable: false, type: 'varchar' })
-    projectId: string;
-  
-    @Column({ name: 'endpoint', nullable: false, type: 'varchar' })
-    endpoint: string;
-  
-    @Column({ name: 'access_token', nullable: true, type: 'varchar' })
-    accessToken: string;
-  
-    @Column({ name: 'request', nullable: true, type: 'text' })
-    request: string;
-  
-    @Column({ name: 'response', nullable: false, type: 'text' })
-    response: string;
-  
-    @Column({ name: 'status_code', type: 'varchar', default: '' })
-    statusCode: string;
-  
-    @Column({ name: 'duration', nullable: true, type: 'varchar' })
-    duration: string;
-  
-    @Column({ name: 'ip', nullable: true, type: 'varchar' })
-    ip: string;
-  
-    @UpdateDateColumn({ type: 'timestamp', name: 'call_date' })
-    callDate: string;
-  }
+@Entity('requests')
+export class Requests {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'projectId', nullable: false, type: 'varchar' })
+  projectId: string;
+
+  @Column({ name: 'endpoint', nullable: false, type: 'text' })
+  endpoint: string;
+
+  @Column({ name: 'access_token', nullable: true, type: 'varchar' })
+  accessToken: string;
+
+  @Column({ name: 'request', nullable: true, type: 'text' })
+  request: string;
+
+  @Column({ name: 'response', nullable: false, type: 'text' })
+  response: string;
+
+  @Column({ name: 'status_code', type: 'varchar', default: '' })
+  statusCode: string;
+
+  @Column({ name: 'duration', nullable: true, type: 'varchar' })
+  duration: string;
+
+  @Column({ name: 'ip', nullable: true, type: 'varchar' })
+  ip: string;
+
+  @UpdateDateColumn({ type: 'timestamp', name: 'call_date' })
+  callDate: string;
+}

--- a/src/modules/role/controllers/role.controller.ts
+++ b/src/modules/role/controllers/role.controller.ts
@@ -6,11 +6,14 @@ import {
   Param,
   ParseIntPipe,
   Patch,
-  Post,
-} from '@nestjs/common';
+  Post, UseGuards
+} from "@nestjs/common";
 import { Role } from '../entities/role.entity';
 import { RoleService } from '../services/role.service';
 import { GetRoleDto } from '../dto';
+import { AuthGuard } from "@nestjs/passport";
+import { RoleGuard } from "../guards/role.guard";
+import { RoleProtect } from "../decorators/role.decorator";
 
 @Controller('role')
 export class RoleController {

--- a/src/modules/role/guards/role.guard.ts
+++ b/src/modules/role/guards/role.guard.ts
@@ -23,9 +23,6 @@ export class RoleGuard implements CanActivate {
         roles.includes(roleGranted.role.name),
       );
 
-    console.log('User:', user);
-    console.log("User's roles:", user.rolesGranted);
-
     return user && user.rolesGranted && hasRole();
   }
 }

--- a/src/modules/role/guards/role.guard.ts
+++ b/src/modules/role/guards/role.guard.ts
@@ -4,20 +4,28 @@ import { Reflector } from '@nestjs/core';
 @Injectable()
 export class RoleGuard implements CanActivate {
   constructor(private readonly _reflector: Reflector) {}
+
   canActivate(context: ExecutionContext): boolean {
     const roles: string[] = this._reflector.get<string[]>(
       'roles',
       context.getHandler(),
     );
 
-    if (!roles) return true;
+    if (!roles) {
+      return true;
+    }
 
     const request = context.switchToHttp().getRequest();
-
     const { user } = request;
-    const hasRole = () =>
-      user.roles.some((role: string) => roles.includes(role));
 
-    return user && user.roles && hasRole();
+    const hasRole = () =>
+      user.rolesGranted.some((roleGranted) =>
+        roles.includes(roleGranted.role.name),
+      );
+
+    console.log('User:', user);
+    console.log("User's roles:", user.rolesGranted);
+
+    return user && user.rolesGranted && hasRole();
   }
 }

--- a/src/modules/token/controllers/token.controller.ts
+++ b/src/modules/token/controllers/token.controller.ts
@@ -21,7 +21,7 @@ import { ApiKeyGuard } from '../../project/guards/api-key.guard';
 import { RoleProtect } from '../../role/decorators/role.decorator';
 
 @Controller('token')
-@UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
+@UseGuards(ApiKeyGuard)
 export class TokenController {
   constructor(
     private readonly tokenService: TokenService,

--- a/src/modules/token/controllers/token.controller.ts
+++ b/src/modules/token/controllers/token.controller.ts
@@ -5,17 +5,21 @@ import {
   HttpCode,
   HttpStatus,
   Post,
-  Query,
+  Query, UseGuards,
   UsePipes,
-  ValidationPipe,
-} from '@nestjs/common';
+  ValidationPipe
+} from "@nestjs/common";
 
 // Local Dependencies.
 import { WalletService } from '../../wallet/services/wallet.service';
 import { TokenService } from '../services/token.service';
 import { DeployTokenDto } from '../dto/deploy-token.dto';
+import { AuthGuard } from "@nestjs/passport";
+import { RoleGuard } from "../../role/guards/role.guard";
+import { ApiKeyGuard } from "../../project/guards/api-key.guard";
 
 @Controller('token')
+@UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
 export class TokenController {
   constructor(
     private readonly tokenService: TokenService,

--- a/src/modules/token/controllers/token.controller.ts
+++ b/src/modules/token/controllers/token.controller.ts
@@ -5,18 +5,20 @@ import {
   HttpCode,
   HttpStatus,
   Post,
-  Query, UseGuards,
+  Query,
+  UseGuards,
   UsePipes,
-  ValidationPipe
-} from "@nestjs/common";
+  ValidationPipe,
+} from '@nestjs/common';
 
 // Local Dependencies.
 import { WalletService } from '../../wallet/services/wallet.service';
 import { TokenService } from '../services/token.service';
 import { DeployTokenDto } from '../dto/deploy-token.dto';
-import { AuthGuard } from "@nestjs/passport";
-import { RoleGuard } from "../../role/guards/role.guard";
-import { ApiKeyGuard } from "../../project/guards/api-key.guard";
+import { AuthGuard } from '@nestjs/passport';
+import { RoleGuard } from '../../role/guards/role.guard';
+import { ApiKeyGuard } from '../../project/guards/api-key.guard';
+import { RoleProtect } from '../../role/decorators/role.decorator';
 
 @Controller('token')
 @UseGuards(AuthGuard('jwt'), RoleGuard, ApiKeyGuard)
@@ -35,6 +37,7 @@ export class TokenController {
   @Post()
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.CREATED)
+  @RoleProtect('MEMBER', 'ADMIN', 'SUPER_ADMIN')
   async deployERC20Token(
     @Body() tokenParams: DeployTokenDto,
     @Query('chain') chain: string,

--- a/src/modules/token/token.module.ts
+++ b/src/modules/token/token.module.ts
@@ -10,9 +10,10 @@ import { TokenService } from './services/token.service';
 import { WalletModule } from '../wallet/wallet.module';
 import { Middleware } from '../../middleware/nft.middleware';
 import { RequestModule } from "../requests/request.module";
+import { ProjectModule } from "../project/project.module";
 
 @Module({
-  imports: [ConfigModule, WalletModule, TypeOrmModule.forFeature([Network]), RequestModule],
+  imports: [ConfigModule, WalletModule, TypeOrmModule.forFeature([Network]), RequestModule, ProjectModule],
   controllers: [TokenController],
   providers: [TokenService],
   exports: [TokenService],


### PR DESCRIPTION
Se implemento la logica para proteger las rutas de project

- Se creo el ApiKeyGuard - que se encarga de hacer toda la validacion de proyecto con usuario.
- Se modifico el JwtStrategy para que retorne el usuario y lo el antiguo payload.
- Se modifico el RoleGuard ya que este no funcionaba.
- Se modifco la entidad de Requests ( especificamente la columna enpoint ) ya que esta tenia un formato muy corto para una url
- Se agregaron los decoradores de Proteccion por Role, Auth y Project a las rutas de nft y token.

